### PR TITLE
Fix npe when unsubscribe before google api is connected

### DIFF
--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
@@ -38,7 +38,9 @@ public class LocationUpdatesObservable extends BaseLocationObservable<Location> 
     protected void onUnsubscribed(GoogleApiClient locationClient) {
         if (locationClient.isConnected()) {
             LocationServices.FusedLocationApi.removeLocationUpdates(locationClient, listener);
-            listener.unsubscribe();
+            if (listener != null) {
+              listener.unsubscribe();
+            }
         }
     }
 

--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
@@ -2,6 +2,7 @@ package pl.charmas.android.reactivelocation.observables.location;
 
 import android.content.Context;
 import android.location.Location;
+import android.support.annotation.Nullable;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationListener;
@@ -21,7 +22,7 @@ public class LocationUpdatesObservable extends BaseLocationObservable<Location> 
     }
 
     private final LocationRequest locationRequest;
-    private UnsubscribableLocationListener listener;
+    @Nullable private UnsubscribableLocationListener listener;
 
     private LocationUpdatesObservable(Context ctx, LocationRequest locationRequest) {
         super(ctx);

--- a/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
+++ b/android-reactive-location/src/main/java/pl/charmas/android/reactivelocation/observables/location/LocationUpdatesObservable.java
@@ -38,8 +38,8 @@ public class LocationUpdatesObservable extends BaseLocationObservable<Location> 
     protected void onUnsubscribed(GoogleApiClient locationClient) {
         if (locationClient.isConnected()) {
             LocationServices.FusedLocationApi.removeLocationUpdates(locationClient, listener);
+            listener.unsubscribe();
         }
-        listener.unsubscribe();
     }
 
     static class UnsubscribableLocationListener implements LocationListener {


### PR DESCRIPTION
### What is new in this Pull Request ?

This PR only unsubscribe to the leaked listener when the google api client is connected.